### PR TITLE
Backend review pass - fixes and tests across #4-#12

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ See each project's README for details:
 ```bash
 cd backend
 npm install
-cp .env-example .env     # fill in your values
-docker compose up -d     # PostgreSQL on :5433, pgAdmin on :8080
+cp .env-example .env     # defaults work; edit if needed
+npm run db:up            # PostgreSQL on :5433, pgAdmin on :8080
+npm run db:migrate       # apply schema
+npm run db:seed          # load test users and schedule
 npm run dev              # http://localhost:3000
 ```
+
+See the [backend README](backend/README.md) for the full script reference and seeded credentials.
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,23 @@ Use conventional commit types: `feat`, `fix`, `refactor`, `chore`, `docs`, `styl
 - Another team member reviews before merging
 - Reference the issue in the PR description
 
-### Linting
+### Checks
 
-Both projects use ESLint + Prettier. Run before committing:
+Both projects use TypeScript + ESLint + Prettier.
+
+**Backend** (from `backend/`):
 
 ```bash
-cd backend   # or cd frontend
-npm run lint        # check for issues
+npm run check       # typecheck + lint + format, all read-only
+npm run lint:fix    # auto-fix ESLint issues
+npm run format      # auto-fix Prettier issues
+```
+
+**Frontend** (from `frontend/`):
+
+```bash
+npm run lint        # ESLint check
 npm run lint:fix    # auto-fix
 ```
+
+(Frontend doesn't yet have the combined `check` / `typecheck` / `format` scripts. Align with backend when convenient.)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ npm run db:seed          # load test users and schedule
 npm run dev              # http://localhost:3000
 ```
 
+With the server running, `npm test` (in another terminal) runs the full integration suite against it.
+
 See the [backend README](backend/README.md) for the full script reference and seeded credentials.
 
 ### Frontend

--- a/backend/.env-example
+++ b/backend/.env-example
@@ -17,3 +17,8 @@ PGADMIN_PORT=8080
 
 # Auth — used to sign and verify JWT tokens
 JWT_SECRET=change-me-to-something-secret
+
+# Logging — Winston format switches on NODE_ENV ('production' is JSON, otherwise pretty-printed).
+# Default log level is 'debug' in dev, 'info' in production.
+# Set LOG_LEVEL to override (e.g. LOG_LEVEL=info to quiet the dev terminal).
+NODE_ENV=development

--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+check-schedule.mjs

--- a/backend/README.md
+++ b/backend/README.md
@@ -65,13 +65,13 @@ Starts the server with `tsx watch` - auto-restarts on file changes.
 
 ## Scripts
 
+### Dev
+
 - `npm run dev` - start dev server with hot reload
 - `npm run build` - compile TypeScript to `dist/`
 - `npm run start` - run compiled output (production)
-- `npm run lint` / `lint:fix` - ESLint
-- `npm run format` - Prettier
 
-Database scripts:
+### Database
 
 - `npm run db:up` / `db:down` - start/stop Postgres + pgAdmin containers
 - `npm run db:migrate` - apply pending migrations and regenerate Prisma Client (prompts for a name if schema changed)
@@ -79,6 +79,19 @@ Database scripts:
 - `npm run db:reset` - drop DB, reapply all migrations, re-run seed (destructive)
 - `npm run db:seed` - run `prisma/seed.ts`
 - `npm run db:studio` - open Prisma Studio on http://localhost:51212
+
+### Tests
+
+Integration tests hit a running server via curl. Start the server in another terminal first (`npm run dev`), then:
+
+- `npm run test:auth` - login and role-based auth
+
+### Quality checks
+
+- `npm run check` - runs typecheck + lint + format check; use before committing
+- `npm run typecheck` - TypeScript compile without emitting
+- `npm run lint` / `lint:fix` - ESLint check / auto-fix
+- `npm run format` / `format:check` - Prettier write / check-only
 
 ## Project Structure
 
@@ -88,12 +101,19 @@ prisma/
 ├── migrations/           # Ordered SQL migrations generated from schema changes
 └── seed.ts               # Populates test data (users, availability, schedule)
 
+scripts/
+└── api/                  # Integration test scripts (bash + curl) per endpoint group
+    ├── _common.sh        # Shared helpers (sourced, not run directly)
+    └── test-auth.sh
+
 src/
-├── index.ts              # Entry point - Express app, mounts routes
+├── index.ts              # Entry point - Express app, boot-time config check, mounts routes
 ├── schema.ts             # Zod schemas - single source of truth for input validation
 ├── lib/
 │   ├── prisma.ts         # Prisma Client singleton (shared across services)
 │   └── logger.ts         # Winston logger
+├── types/
+│   └── express.d.ts      # Augments Express Request with req.user
 ├── routes/               # Route definitions - HTTP method + path + middleware chain
 │   ├── auth.ts
 │   ├── employees.ts

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,6 +87,7 @@ Integration tests hit a running server via curl. Start the server in another ter
 - `npm run test:auth` - login and role-based auth
 - `npm run test:employees` - `/employees` list, create, get by id
 - `npm run test:availability` - `/availability/:id` get (with filters) + put
+- `npm run test:schedule` - `/schedule` get (with filters, role scoping) + put
 
 ### Quality checks
 
@@ -108,7 +109,8 @@ scripts/
     ├── _common.sh        # Shared helpers (sourced, not run directly)
     ├── test-auth.sh
     ├── test-employees.sh
-    └── test-availability.sh
+    ├── test-availability.sh
+    └── test-schedule.sh
 
 src/
 ├── index.ts              # Entry point - Express app, boot-time config check, mounts routes

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,84 +8,111 @@
 npm install
 ```
 
-### 2. Start the database
+### 2. Configure environment variables
 
 ```bash
 cp .env-example .env
-docker compose up -d
+```
+
+The `.env` file is gitignored - never commit it. Defaults work out of the box; adjust if you need different ports or credentials.
+
+#### App variables
+
+- **PORT** - port the Express server runs on (default `3000`)
+- **DATABASE_URL** - PostgreSQL connection string that Prisma uses. Format: `postgresql://USER:PASSWORD@HOST:PORT/DB_NAME`
+- **JWT_SECRET** - secret key for signing/verifying JWT auth tokens. Keep it private.
+
+#### Docker Compose variables (used by `compose.yml`)
+
+- **POSTGRES_USER** - database user (default `root`)
+- **POSTGRES_PASSWORD** - database password (default `root`)
+- **POSTGRES_DB** - database name (default `employee_scheduling`)
+- **POSTGRES_PORT** - host port mapped to PostgreSQL (default `5433`)
+- **PGADMIN_EMAIL** - pgAdmin login email
+- **PGADMIN_PASSWORD** - pgAdmin login password
+- **PGADMIN_PORT** - host port mapped to pgAdmin (default `8080`)
+
+### 3. Start the database
+
+```bash
+npm run db:up
 ```
 
 This starts PostgreSQL on port 5433 and pgAdmin on port 8080.
 
-- **pgAdmin UI** — http://localhost:8080 (login: `admin@admin.com` / `admin`)
-- **PostgreSQL** — `localhost:5433` (user: `root`, password: `root`, db: `employee_scheduling`)
+- **pgAdmin UI** - http://localhost:8080 (login: `admin@admin.com` / `admin`)
+- **PostgreSQL** - `localhost:5433` (user: `root`, password: `root`, db: `employee_scheduling`)
 
-### 3. Configure environment variables
-
-Copy the example file and fill in your values:
+### 4. Apply schema and seed data
 
 ```bash
-cp .env-example .env
+npm run db:migrate   # applies pending migrations, generates Prisma Client
+npm run db:seed      # populates test users, availability, and schedule
 ```
 
-The `.env` file is gitignored — never commit it.
+Seeded accounts (password `password123` for all):
 
-#### App variables
+- `owner@company.com` - employer
+- `juan.garcia@company.com`, `maria.fernandez@company.com`, `pedro.martinez@company.com` - employees
 
-- **PORT** — port the Express server runs on (default `3000`)
-- **DATABASE_URL** — PostgreSQL connection string that Prisma uses to connect. Format: `postgresql://USER:PASSWORD@HOST:PORT/DB_NAME`
-- **JWT_SECRET** — secret key for signing/verifying JWT auth tokens. Keep it private.
-
-#### Docker Compose variables (used by `compose.yml`)
-
-- **POSTGRES_USER** — database user (default `root`)
-- **POSTGRES_PASSWORD** — database password (default `root`)
-- **POSTGRES_DB** — database name (default `employee_scheduling`)
-- **POSTGRES_PORT** — host port mapped to PostgreSQL (default `5433`)
-- **PGADMIN_EMAIL** — pgAdmin login email
-- **PGADMIN_PASSWORD** — pgAdmin login password
-- **PGADMIN_PORT** — host port mapped to pgAdmin (default `8080`)
-
-### 4. Run the dev server
+### 5. Run the dev server
 
 ```bash
 npm run dev
 ```
 
-Starts the server with `tsx watch` — auto-restarts on file changes.
+Starts the server with `tsx watch` - auto-restarts on file changes.
 
 ## Scripts
 
-- `npm run dev` — start dev server with hot reload
-- `npm run build` — compile TypeScript to `dist/`
-- `npm run start` — run compiled output (production)
-- `npm run lint` — run ESLint
-- `npm run lint:fix` — auto-fix lint issues
+- `npm run dev` - start dev server with hot reload
+- `npm run build` - compile TypeScript to `dist/`
+- `npm run start` - run compiled output (production)
+- `npm run lint` / `lint:fix` - ESLint
+- `npm run format` - Prettier
+
+Database scripts:
+
+- `npm run db:up` / `db:down` - start/stop Postgres + pgAdmin containers
+- `npm run db:migrate` - apply pending migrations and regenerate Prisma Client (prompts for a name if schema changed)
+- `npm run db:generate` - regenerate Prisma Client only (rare; use after dep bumps if types look stale)
+- `npm run db:reset` - drop DB, reapply all migrations, re-run seed (destructive)
+- `npm run db:seed` - run `prisma/seed.ts`
+- `npm run db:studio` - open Prisma Studio on http://localhost:51212
 
 ## Project Structure
 
 ```
+prisma/
+├── schema.prisma         # Database models - source of truth for table structure
+├── migrations/           # Ordered SQL migrations generated from schema changes
+└── seed.ts               # Populates test data (users, availability, schedule)
+
 src/
-├── index.ts              # Entry point — Express app, mounts routes
-├── schema.ts             # Zod schemas — single source of truth for input validation
-├── routes/               # Route definitions — HTTP method + path + middleware chain
+├── index.ts              # Entry point - Express app, mounts routes
+├── schema.ts             # Zod schemas - single source of truth for input validation
+├── lib/
+│   ├── prisma.ts         # Prisma Client singleton (shared across services)
+│   └── logger.ts         # Winston logger
+├── routes/               # Route definitions - HTTP method + path + middleware chain
 │   ├── auth.ts
 │   ├── employees.ts
 │   ├── availability.ts
 │   └── schedule.ts
-├── controllers/          # Request handlers — parse request, call service, send response
+├── controllers/          # Request handlers - parse request, call service, send response
 │   ├── auth.ts
 │   ├── employees.ts
 │   ├── availability.ts
 │   └── schedule.ts
-├── services/             # Business logic — Prisma queries, data processing
+├── services/             # Business logic - Prisma queries, data processing
 │   ├── auth.ts
 │   ├── employees.ts
 │   ├── availability.ts
 │   └── schedule.ts
-└── middleware/            # Reusable middleware — runs before controllers
+└── middleware/           # Reusable middleware - runs before controllers
     ├── auth.ts           # JWT verification + role-based access
     ├── validate.ts       # Zod schema validation (generic)
+    ├── requestLogger.ts  # Logs every request with status + duration
     └── errorHandler.ts   # Global error handler
 ```
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,6 +85,7 @@ Starts the server with `tsx watch` - auto-restarts on file changes.
 Integration tests hit a running server via curl. Start the server in another terminal first (`npm run dev`), then:
 
 - `npm run test:auth` - login and role-based auth
+- `npm run test:employees` - `/employees` list, create, get by id
 
 ### Quality checks
 
@@ -104,7 +105,8 @@ prisma/
 scripts/
 └── api/                  # Integration test scripts (bash + curl) per endpoint group
     ├── _common.sh        # Shared helpers (sourced, not run directly)
-    └── test-auth.sh
+    ├── test-auth.sh
+    └── test-employees.sh
 
 src/
 ├── index.ts              # Entry point - Express app, boot-time config check, mounts routes

--- a/backend/README.md
+++ b/backend/README.md
@@ -86,6 +86,7 @@ Integration tests hit a running server via curl. Start the server in another ter
 
 - `npm run test:auth` - login and role-based auth
 - `npm run test:employees` - `/employees` list, create, get by id
+- `npm run test:availability` - `/availability/:id` get (with filters) + put
 
 ### Quality checks
 
@@ -106,7 +107,8 @@ scripts/
 └── api/                  # Integration test scripts (bash + curl) per endpoint group
     ├── _common.sh        # Shared helpers (sourced, not run directly)
     ├── test-auth.sh
-    └── test-employees.sh
+    ├── test-employees.sh
+    └── test-availability.sh
 
 src/
 ├── index.ts              # Entry point - Express app, boot-time config check, mounts routes

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,8 @@ The `.env` file is gitignored - never commit it. Defaults work out of the box; a
 - **PORT** - port the Express server runs on (default `3000`)
 - **DATABASE_URL** - PostgreSQL connection string that Prisma uses. Format: `postgresql://USER:PASSWORD@HOST:PORT/DB_NAME`
 - **JWT_SECRET** - secret key for signing/verifying JWT auth tokens. Keep it private.
+- **NODE_ENV** - set to `production` to switch Winston logs to JSON; otherwise pretty-printed for dev terminals.
+- **LOG_LEVEL** - optional override (`debug`, `info`, `warn`, `error`). Defaults to `info` in production and `debug` otherwise.
 
 #### Docker Compose variables (used by `compose.yml`)
 
@@ -118,7 +120,7 @@ src/
 ├── schema.ts             # Zod schemas - single source of truth for input validation
 ├── lib/
 │   ├── prisma.ts         # Prisma Client singleton (shared across services)
-│   └── logger.ts         # Winston logger
+│   └── logger.ts         # Winston logger (pretty in dev, JSON in production)
 ├── types/
 │   └── express.d.ts      # Augments Express Request with req.user
 ├── routes/               # Route definitions - HTTP method + path + middleware chain

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,6 +84,7 @@ Starts the server with `tsx watch` - auto-restarts on file changes.
 
 Integration tests hit a running server via curl. Start the server in another terminal first (`npm run dev`), then:
 
+- `npm test` - run every suite below in order; stops at the first failure
 - `npm run test:auth` - login and role-based auth
 - `npm run test:employees` - `/employees` list, create, get by id
 - `npm run test:availability` - `/availability/:id` get (with filters) + put
@@ -137,7 +138,7 @@ src/
 │   └── schedule.ts
 └── middleware/           # Reusable middleware - runs before controllers
     ├── auth.ts           # JWT verification + role-based access
-    ├── validate.ts       # Zod schema validation (generic)
+    ├── validate.ts       # Zod validation for req.body or req.query
     ├── requestLogger.ts  # Logs every request with status + duration
     └── errorHandler.ts   # Global error handler
 ```
@@ -152,6 +153,6 @@ Request → Route → Middleware (auth, validate) → Controller → Service →
 
 - **Route** — wiring only: maps a path to middleware + a controller function
 - **Middleware** — cross-cutting concerns reused across routes (auth, validation, errors)
-- **Controller** — HTTP layer: reads params/body, calls the service, picks the status code
+- **Controller** — HTTP layer: reads params/body/query, calls the service, picks the status code
 - **Service** — business logic: no knowledge of HTTP, works with plain data and Prisma
 - **Schema** — Zod schemas define valid input shapes, also export TypeScript types via `z.infer`

--- a/backend/eslint.config.ts
+++ b/backend/eslint.config.ts
@@ -5,7 +5,7 @@ import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'check-schedule.mjs']),
   {
     files: ['**/*.ts'],
     plugins: { js },

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "test:auth": "./scripts/api/test-auth.sh",
     "test:employees": "./scripts/api/test-employees.sh",
     "test:availability": "./scripts/api/test-availability.sh",
+    "test:schedule": "./scripts/api/test-schedule.sh",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,9 +14,12 @@
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
     "test:auth": "./scripts/api/test-auth.sh",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint": "eslint . --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "check": "npm run typecheck && npm run lint && npm run format:check"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "db:reset": "prisma migrate reset",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
+    "test:auth": "./scripts/api/test-auth.sh",
     "lint:fix": "eslint . --fix",
     "lint": "eslint . --fix",
     "format": "prettier --write ."

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "db:studio": "prisma studio",
     "test:auth": "./scripts/api/test-auth.sh",
     "test:employees": "./scripts/api/test-employees.sh",
+    "test:availability": "./scripts/api/test-availability.sh",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
     "test:auth": "./scripts/api/test-auth.sh",
+    "test:employees": "./scripts/api/test-employees.sh",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "db:down": "docker compose down",
     "db:migrate": "prisma migrate dev && prisma generate",
     "db:generate": "prisma generate",
-    "db:reset": "prisma migrate reset",
+    "db:reset": "prisma migrate reset && prisma db seed",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
     "test:auth": "./scripts/api/test-auth.sh",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,13 @@
     "dev": "tsx watch --env-file .env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down",
+    "db:migrate": "prisma migrate dev && prisma generate",
+    "db:generate": "prisma generate",
+    "db:reset": "prisma migrate reset",
+    "db:seed": "prisma db seed",
+    "db:studio": "prisma studio",
     "lint:fix": "eslint . --fix",
     "lint": "eslint . --fix",
     "format": "prettier --write ."

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "db:reset": "prisma migrate reset && prisma db seed",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
+    "test": "npm run test:auth && npm run test:employees && npm run test:availability && npm run test:schedule",
     "test:auth": "./scripts/api/test-auth.sh",
     "test:employees": "./scripts/api/test-employees.sh",
     "test:availability": "./scripts/api/test-availability.sh",

--- a/backend/prisma/migrations/20260415151139_fix_employee_avatar_and_user_fk/migration.sql
+++ b/backend/prisma/migrations/20260415151139_fix_employee_avatar_and_user_fk/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Employee" ALTER COLUMN "avatar" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Employee" ADD CONSTRAINT "Employee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260415153917_remove_user_name/migration.sql
+++ b/backend/prisma/migrations/20260415153917_remove_user_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "name";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,10 +21,9 @@ enum ShiftType {
 
 model User {
   id String @id @default(uuid())
-  name String
   email String @unique
   passwordHash String
-  role Role 
+  role Role
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -11,24 +11,42 @@ const pool = new Pool({ connectionString });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 
+type ShiftType = 'MORNING' | 'AFTERNOON' | 'NIGHT';
+
+function getMonday(d: Date): Date {
+  const date = new Date(d);
+  date.setHours(0, 0, 0, 0);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  return date;
+}
+
+function addDays(d: Date, n: number): Date {
+  const date = new Date(d);
+  date.setDate(date.getDate() + n);
+  return date;
+}
+
 async function main() {
+  // Shared password for all seeded accounts — dev only.
   const defaultPasswordHash = await hash('password123', 10);
 
+  // Employer — single owner account used to manage the schedule.
   await prisma.user.upsert({
     where: { email: 'owner@company.com' },
     update: {
-      name: 'Owner Employer',
       role: 'EMPLOYER',
       passwordHash: defaultPasswordHash,
     },
     create: {
-      name: 'Owner Employer',
       email: 'owner@company.com',
       passwordHash: defaultPasswordHash,
       role: 'EMPLOYER',
     },
   });
 
+  // Employees — staff profiles, each with a matching User account for login.
   const employees = [
     {
       firstName: 'Juan',
@@ -56,23 +74,23 @@ async function main() {
     },
   ];
 
+  const employeeRecordsByEmail = new Map<string, { id: string }>();
+
   for (const employee of employees) {
     const user = await prisma.user.upsert({
       where: { email: employee.email },
       update: {
-        name: `${employee.firstName} ${employee.lastName}`,
         role: 'EMPLOYEE',
         passwordHash: defaultPasswordHash,
       },
       create: {
-        name: `${employee.firstName} ${employee.lastName}`,
         email: employee.email,
         passwordHash: defaultPasswordHash,
         role: 'EMPLOYEE',
       },
     });
 
-    await prisma.employee.upsert({
+    const record = await prisma.employee.upsert({
       where: { userId: user.id },
       update: {
         firstName: employee.firstName,
@@ -90,9 +108,103 @@ async function main() {
         avatar: employee.avatar,
       },
     });
+
+    employeeRecordsByEmail.set(employee.email, { id: record.id });
   }
 
-  console.log('Seed completed: 1 employer and 3 employees');
+  // Seed availability and schedule for the current week (Mon-Sun).
+  const monday = getMonday(new Date());
+  const weekDates = Array.from({ length: 7 }, (_, i) => addDays(monday, i));
+
+  const juanId = employeeRecordsByEmail.get('juan.garcia@company.com')!.id;
+  const mariaId = employeeRecordsByEmail.get('maria.fernandez@company.com')!.id;
+  const pedroId = employeeRecordsByEmail.get('pedro.martinez@company.com')!.id;
+
+  const allShifts: ShiftType[] = ['MORNING', 'AFTERNOON', 'NIGHT'];
+
+  // Availability patterns per employee.
+  const availabilityPatterns: Array<{
+    employeeId: string;
+    pattern: (dayIndex: number, shift: ShiftType) => boolean;
+  }> = [
+    {
+      // Juan (Chef): weekdays all shifts, weekends off.
+      employeeId: juanId,
+      pattern: (dayIndex) => dayIndex < 5,
+    },
+    {
+      // Maria (Waiter): weekdays afternoon/night, weekends night only.
+      employeeId: mariaId,
+      pattern: (dayIndex, shift) => {
+        if (dayIndex < 5) return shift !== 'MORNING';
+        return shift === 'NIGHT';
+      },
+    },
+    {
+      // Pedro (Barista): weekday mornings, weekend morning+afternoon.
+      employeeId: pedroId,
+      pattern: (dayIndex, shift) => {
+        if (dayIndex < 5) return shift === 'MORNING';
+        return shift !== 'NIGHT';
+      },
+    },
+  ];
+
+  let availabilityCount = 0;
+  for (const { employeeId, pattern } of availabilityPatterns) {
+    for (let dayIndex = 0; dayIndex < weekDates.length; dayIndex++) {
+      const date = weekDates[dayIndex]!;
+      for (const shiftType of allShifts) {
+        const isAvailable = pattern(dayIndex, shiftType);
+        await prisma.availability.upsert({
+          where: {
+            employeeId_date_shiftType: { employeeId, date, shiftType },
+          },
+          update: { isAvailable },
+          create: { employeeId, date, shiftType, isAvailable },
+        });
+        availabilityCount++;
+      }
+    }
+  }
+
+  // Schedule entries: a partial week so there's data to read AND open slots to fill via PUT.
+  const scheduleAssignments: Array<{
+    dayIndex: number;
+    shiftType: ShiftType;
+    employeeId: string;
+  }> = [
+    { dayIndex: 0, shiftType: 'MORNING', employeeId: pedroId },
+    { dayIndex: 0, shiftType: 'AFTERNOON', employeeId: juanId },
+    { dayIndex: 0, shiftType: 'AFTERNOON', employeeId: mariaId },
+    { dayIndex: 1, shiftType: 'MORNING', employeeId: pedroId },
+    { dayIndex: 1, shiftType: 'AFTERNOON', employeeId: juanId },
+    { dayIndex: 2, shiftType: 'MORNING', employeeId: pedroId },
+    { dayIndex: 2, shiftType: 'NIGHT', employeeId: mariaId },
+  ];
+
+  for (const entry of scheduleAssignments) {
+    const date = weekDates[entry.dayIndex]!;
+    await prisma.scheduleEntry.upsert({
+      where: {
+        employeeId_date_shiftType: {
+          employeeId: entry.employeeId,
+          date,
+          shiftType: entry.shiftType,
+        },
+      },
+      update: {},
+      create: {
+        employeeId: entry.employeeId,
+        date,
+        shiftType: entry.shiftType,
+      },
+    });
+  }
+
+  console.log(
+    `Seed completed: 1 employer, ${employees.length} employees, ${availabilityCount} availability rows, ${scheduleAssignments.length} scheduled shifts`,
+  );
 }
 
 main()

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -13,18 +13,22 @@ const prisma = new PrismaClient({ adapter });
 
 type ShiftType = 'MORNING' | 'AFTERNOON' | 'NIGHT';
 
+// Work in UTC so @db.Date columns store the same YYYY-MM-DD regardless of
+// the machine's timezone. Local-time math drifts by one day in timezones
+// east of UTC.
 function getMonday(d: Date): Date {
-  const date = new Date(d);
-  date.setHours(0, 0, 0, 0);
-  const day = date.getDay();
+  const date = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+  const day = date.getUTCDay();
   const diff = day === 0 ? -6 : 1 - day;
-  date.setDate(date.getDate() + diff);
+  date.setUTCDate(date.getUTCDate() + diff);
   return date;
 }
 
 function addDays(d: Date, n: number): Date {
   const date = new Date(d);
-  date.setDate(date.getDate() + n);
+  date.setUTCDate(date.getUTCDate() + n);
   return date;
 }
 

--- a/backend/scripts/api/_common.sh
+++ b/backend/scripts/api/_common.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Shared helpers for API test scripts.
+# Do not run this file directly — source it from test-*.sh scripts.
+
+set -euo pipefail
+
+# --- Config ----------------------------------------------------------------
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+
+# Seeded credentials (see prisma/seed.ts). Override via env if needed.
+EMPLOYER_EMAIL="${EMPLOYER_EMAIL:-owner@company.com}"
+EMPLOYEE_EMAIL="${EMPLOYEE_EMAIL:-juan.garcia@company.com}"
+PASSWORD="${PASSWORD:-password123}"
+
+# --- Dependency check -------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed." >&2
+  echo "  Install with: brew install jq" >&2
+  exit 1
+fi
+
+# --- Output helpers ---------------------------------------------------------
+
+GREEN=$'\033[0;32m'
+RED=$'\033[0;31m'
+YELLOW=$'\033[0;33m'
+CYAN=$'\033[0;36m'
+RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+info() {
+  printf "%b\n" "${CYAN}[info]${RESET} $*"
+}
+
+section() {
+  printf "\n%b\n" "${YELLOW}=== $* ===${RESET}"
+}
+
+pass() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf "%b\n" "  ${GREEN}✓${RESET} $*"
+}
+
+fail() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf "%b\n" "  ${RED}✗${RESET} $*"
+}
+
+summary() {
+  printf "\n"
+  if [ "$TESTS_FAILED" -eq 0 ]; then
+    printf "%b\n" "${GREEN}All $TESTS_RUN tests passed.${RESET}"
+  else
+    printf "%b\n" "${RED}$TESTS_FAILED of $TESTS_RUN tests failed.${RESET}"
+    exit 1
+  fi
+}
+
+# --- Request helpers --------------------------------------------------------
+
+# Perform a request, capture body and status. Populates globals:
+#   RESPONSE_BODY, RESPONSE_STATUS
+# Usage:
+#   request METHOD PATH [--data JSON] [--auth TOKEN]
+request() {
+  local method="$1"
+  local path="$2"
+  shift 2
+
+  local data=""
+  local token=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --data) data="$2"; shift 2 ;;
+      --auth) token="$2"; shift 2 ;;
+      *) echo "Unknown arg: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local args=(-s -w "\n%{http_code}" -X "$method" "$BASE_URL$path"
+              -H "Content-Type: application/json")
+  if [ -n "$token" ]; then
+    args+=(-H "Authorization: Bearer $token")
+  fi
+  if [ -n "$data" ]; then
+    args+=(-d "$data")
+  fi
+
+  local raw
+  raw=$(curl "${args[@]}")
+  RESPONSE_STATUS=$(printf '%s' "$raw" | tail -n1)
+  RESPONSE_BODY=$(printf '%s' "$raw" | sed '$d')
+}
+
+# assert_status <expected> <test_name>
+# Checks RESPONSE_STATUS against expected.
+assert_status() {
+  local expected="$1"
+  local name="$2"
+
+  if [ "$RESPONSE_STATUS" = "$expected" ]; then
+    pass "$name (status $expected)"
+  else
+    fail "$name — expected $expected, got $RESPONSE_STATUS. Body: $RESPONSE_BODY"
+  fi
+}
+
+# assert_json_field <jq_path> <expected> <test_name>
+# Checks a field in RESPONSE_BODY against an expected value.
+assert_json_field() {
+  local path="$1"
+  local expected="$2"
+  local name="$3"
+
+  local actual
+  actual=$(printf '%s' "$RESPONSE_BODY" | jq -r "$path" 2>/dev/null || echo "<invalid-json>")
+  if [ "$actual" = "$expected" ]; then
+    pass "$name ($path = $expected)"
+  else
+    fail "$name — expected $path = $expected, got $actual"
+  fi
+}
+
+# login <email> <password>
+# On success, echoes the token to stdout (empty string on failure).
+# Does not touch TESTS_RUN counters — it's a helper, not an assertion.
+login() {
+  local email="$1"
+  local password="$2"
+
+  local raw
+  raw=$(curl -s -X POST "$BASE_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$email\",\"password\":\"$password\"}")
+
+  printf '%s' "$raw" | jq -r '.token // empty'
+}
+
+# check_server — abort early if the server isn't reachable.
+check_server() {
+  if ! curl -sf "$BASE_URL/health" >/dev/null 2>&1; then
+    echo "Error: server not reachable at $BASE_URL/health" >&2
+    echo "  Start it with: npm run dev" >&2
+    exit 1
+  fi
+}

--- a/backend/scripts/api/test-auth.sh
+++ b/backend/scripts/api/test-auth.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Integration tests for POST /auth/login and the auth/role middleware.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=./_common.sh
+source ./_common.sh
+
+check_server
+
+section "Login — happy path"
+
+request POST /auth/login --data "{\"email\":\"$EMPLOYER_EMAIL\",\"password\":\"$PASSWORD\"}"
+assert_status 200 "employer can log in"
+assert_json_field '.user.role' 'EMPLOYER' "response carries EMPLOYER role"
+assert_json_field '.user.email' "$EMPLOYER_EMAIL" "response carries employer email"
+
+request POST /auth/login --data "{\"email\":\"$EMPLOYEE_EMAIL\",\"password\":\"$PASSWORD\"}"
+assert_status 200 "employee can log in"
+assert_json_field '.user.role' 'EMPLOYEE' "response carries EMPLOYEE role"
+
+section "Login — invalid credentials"
+
+request POST /auth/login --data "{\"email\":\"$EMPLOYER_EMAIL\",\"password\":\"wrong-password\"}"
+assert_status 401 "wrong password is rejected"
+
+request POST /auth/login --data "{\"email\":\"nobody@example.com\",\"password\":\"$PASSWORD\"}"
+assert_status 401 "unknown email is rejected"
+
+section "Login — malformed input"
+
+request POST /auth/login --data '{}'
+assert_status 400 "missing body is rejected"
+
+request POST /auth/login --data "{\"email\":\"$EMPLOYER_EMAIL\"}"
+assert_status 400 "missing password is rejected"
+
+request POST /auth/login --data '{"email":"not-an-email","password":"x"}'
+assert_status 400 "invalid email format is rejected"
+
+section "Protected endpoint — authentication"
+
+request GET /employees
+assert_status 401 "request with no token is rejected"
+
+request GET /employees --auth "not.a.valid.token"
+assert_status 401 "request with malformed token is rejected"
+
+request GET /employees --auth "eyJhbGciOiJIUzI1NiJ9.invalid.signature"
+assert_status 401 "request with invalid-signature token is rejected"
+
+section "Protected endpoint — authorization (role)"
+
+employer_token=$(login "$EMPLOYER_EMAIL" "$PASSWORD")
+employee_token=$(login "$EMPLOYEE_EMAIL" "$PASSWORD")
+
+if [ -z "$employer_token" ] || [ -z "$employee_token" ]; then
+  fail "could not obtain tokens for role tests"
+  summary
+fi
+
+request GET /employees --auth "$employer_token"
+assert_status 200 "employer can hit EMPLOYER-only endpoint"
+
+request GET /employees --auth "$employee_token"
+assert_status 403 "employee cannot hit EMPLOYER-only endpoint"
+
+summary

--- a/backend/scripts/api/test-availability.sh
+++ b/backend/scripts/api/test-availability.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Integration tests for the /availability endpoints.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=./_common.sh
+source ./_common.sh
+
+check_server
+
+# Monday of the current week — matches the seed's weekDates[0].
+dow=$(date +%u)
+monday=$(date -v-$((dow - 1))d +%Y-%m-%d)
+sunday=$(date -v+$((7 - dow))d +%Y-%m-%d)
+
+employer_token=$(login "$EMPLOYER_EMAIL" "$PASSWORD")
+juan_token=$(login "juan.garcia@company.com" "$PASSWORD")
+
+if [ -z "$employer_token" ] || [ -z "$juan_token" ]; then
+  fail "could not obtain login tokens — is the DB seeded?"
+  summary
+fi
+
+# Pick Juan's and Maria's employee ids out of the employer's GET /employees list.
+request GET /employees --auth "$employer_token"
+juan_id=$(printf '%s' "$RESPONSE_BODY" | jq -r '.employees[] | select(.email=="juan.garcia@company.com") | .id')
+maria_id=$(printf '%s' "$RESPONSE_BODY" | jq -r '.employees[] | select(.email=="maria.fernandez@company.com") | .id')
+
+if [ -z "$juan_id" ] || [ -z "$maria_id" ]; then
+  fail "could not find seeded employee ids"
+  summary
+fi
+
+info "Monday=$monday  Sunday=$sunday  juan=$juan_id  maria=$maria_id"
+
+section "GET /availability/:employeeId — happy path"
+
+request GET "/availability/$juan_id" --auth "$juan_token"
+assert_status 200 "employee can view own availability"
+count=$(printf '%s' "$RESPONSE_BODY" | jq '.availability | length')
+if [ "$count" -ge 21 ]; then
+  pass "response contains a week of seeded entries (got $count)"
+else
+  fail "expected >= 21 entries for Juan's week, got $count"
+fi
+
+request GET "/availability/$juan_id" --auth "$employer_token"
+assert_status 200 "employer can view any employee's availability"
+
+section "GET /availability/:employeeId — filters"
+
+request GET "/availability/$juan_id?weekOf=$monday" --auth "$juan_token"
+assert_status 200 "weekOf filter returns 200"
+count=$(printf '%s' "$RESPONSE_BODY" | jq '.availability | length')
+if [ "$count" -eq 21 ]; then
+  pass "weekOf returns exactly one week (21 = 7 days * 3 shifts)"
+else
+  fail "expected 21 entries for weekOf=$monday, got $count"
+fi
+
+request GET "/availability/$juan_id?startDate=$monday&endDate=$monday" --auth "$juan_token"
+assert_status 200 "startDate=endDate filter returns 200"
+count=$(printf '%s' "$RESPONSE_BODY" | jq '.availability | length')
+if [ "$count" -eq 3 ]; then
+  pass "single-day range returns 3 entries (one per shift)"
+else
+  fail "expected 3 entries for single day, got $count"
+fi
+
+section "GET /availability/:employeeId — authorization"
+
+request GET "/availability/$maria_id" --auth "$juan_token"
+assert_status 403 "employee cannot view another employee's availability"
+
+section "GET /availability/:employeeId — validation"
+
+request GET "/availability/$juan_id?weekOf=$monday&startDate=$monday" --auth "$juan_token"
+assert_status 400 "weekOf + startDate together is rejected"
+
+request GET "/availability/$juan_id?startDate=2026-01-10&endDate=2026-01-01" --auth "$juan_token"
+assert_status 400 "startDate after endDate is rejected"
+
+request GET "/availability/$juan_id?weekOf=not-a-date" --auth "$juan_token"
+assert_status 400 "invalid date format is rejected"
+
+section "GET /availability/:employeeId — not found"
+
+request GET "/availability/00000000-0000-0000-0000-000000000000" --auth "$employer_token"
+assert_status 404 "unknown but valid uuid returns 404"
+
+section "PUT /availability/:employeeId — happy path"
+
+# Toggle Juan's Monday morning to false, then back to true, asserting each write.
+request PUT "/availability/$juan_id" --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"$monday\",\"shiftType\":\"MORNING\",\"isAvailable\":false}]}"
+assert_status 200 "employee can update own availability"
+assert_json_field '.availability[0].isAvailable' 'false' "isAvailable reflects the write"
+
+request PUT "/availability/$juan_id" --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"$monday\",\"shiftType\":\"MORNING\",\"isAvailable\":true}]}"
+assert_status 200 "re-put toggles the value back"
+assert_json_field '.availability[0].isAvailable' 'true' "isAvailable reflects the new value"
+
+section "PUT /availability/:employeeId — authorization"
+
+request PUT "/availability/$maria_id" --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"$monday\",\"shiftType\":\"MORNING\",\"isAvailable\":true}]}"
+assert_status 403 "employee cannot update another employee's availability"
+
+request PUT "/availability/$juan_id" --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$monday\",\"shiftType\":\"MORNING\",\"isAvailable\":true}]}"
+assert_status 403 "employer cannot update availability"
+
+section "PUT /availability/:employeeId — validation"
+
+request PUT "/availability/$juan_id" --auth "$juan_token" --data '{}'
+assert_status 400 "missing entries is rejected"
+
+request PUT "/availability/$juan_id" --auth "$juan_token" --data '{"entries":[]}'
+assert_status 400 "empty entries array is rejected"
+
+request PUT "/availability/$juan_id" --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"$monday\",\"shiftType\":\"LUNCH\",\"isAvailable\":true}]}"
+assert_status 400 "invalid shiftType is rejected"
+
+request PUT "/availability/$juan_id" --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"not-a-date\",\"shiftType\":\"MORNING\",\"isAvailable\":true}]}"
+assert_status 400 "invalid date is rejected"
+
+summary

--- a/backend/scripts/api/test-employees.sh
+++ b/backend/scripts/api/test-employees.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Integration tests for the /employees endpoints.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=./_common.sh
+source ./_common.sh
+
+check_server
+
+employer_token=$(login "$EMPLOYER_EMAIL" "$PASSWORD")
+employee_token=$(login "$EMPLOYEE_EMAIL" "$PASSWORD")
+
+if [ -z "$employer_token" ] || [ -z "$employee_token" ]; then
+  fail "could not obtain login tokens — is the DB seeded?"
+  summary
+fi
+
+section "GET /employees — happy path"
+
+request GET /employees --auth "$employer_token"
+assert_status 200 "employer can list employees"
+count=$(printf '%s' "$RESPONSE_BODY" | jq '.employees | length')
+if [ "$count" -ge 3 ]; then
+  pass "response contains at least the 3 seeded employees (got $count)"
+else
+  fail "expected >= 3 employees, got $count"
+fi
+
+# Capture a known employee id for subsequent tests.
+known_id=$(printf '%s' "$RESPONSE_BODY" | jq -r '.employees[0].id')
+
+section "GET /employees — authorization"
+
+request GET /employees --auth "$employee_token"
+assert_status 403 "employee cannot list employees"
+
+section "GET /employees/:id — happy path"
+
+request GET "/employees/$known_id" --auth "$employer_token"
+assert_status 200 "employer can fetch an employee by id"
+assert_json_field '.employee.id' "$known_id" "response carries the requested id"
+
+section "GET /employees/:id — authorization"
+
+request GET "/employees/$known_id" --auth "$employee_token"
+assert_status 403 "employee cannot fetch an employee by id"
+
+section "GET /employees/:id — not found"
+
+request GET "/employees/00000000-0000-0000-0000-000000000000" --auth "$employer_token"
+assert_status 404 "unknown but valid uuid returns 404"
+
+request GET "/employees/not-a-uuid" --auth "$employer_token"
+# Either 404 or 400 is defensible; 500 is a bug.
+if [ "$RESPONSE_STATUS" = "404" ] || [ "$RESPONSE_STATUS" = "400" ]; then
+  pass "malformed id is rejected (status $RESPONSE_STATUS)"
+else
+  fail "malformed id should return 404 or 400, got $RESPONSE_STATUS. Body: $RESPONSE_BODY"
+fi
+
+section "POST /employees — happy path"
+
+# Unique email per run so re-runs don't collide.
+new_email="test-$(date +%s)@example.com"
+request POST /employees --auth "$employer_token" --data \
+  "{\"firstName\":\"Test\",\"lastName\":\"User\",\"email\":\"$new_email\",\"password\":\"secret123\",\"phone\":\"070-000\",\"position\":\"Tester\"}"
+assert_status 201 "employer can create an employee"
+assert_json_field '.employee.email' "$new_email" "response echoes the email"
+assert_json_field '.employee.firstName' 'Test' "response carries firstName"
+assert_json_field '.employee.avatar' 'null' "omitted avatar returns null"
+
+section "POST /employees — authorization"
+
+request POST /employees --auth "$employee_token" --data \
+  "{\"firstName\":\"X\",\"lastName\":\"Y\",\"email\":\"denied@example.com\",\"password\":\"p\"}"
+assert_status 403 "employee cannot create an employee"
+
+section "POST /employees — validation"
+
+request POST /employees --auth "$employer_token" --data '{}'
+assert_status 400 "empty body is rejected"
+
+request POST /employees --auth "$employer_token" --data \
+  '{"lastName":"User","email":"x@example.com","password":"secret"}'
+assert_status 400 "missing firstName is rejected"
+
+request POST /employees --auth "$employer_token" --data \
+  '{"firstName":"Test","lastName":"User","password":"secret"}'
+assert_status 400 "missing email is rejected"
+
+request POST /employees --auth "$employer_token" --data \
+  '{"firstName":"Test","lastName":"User","email":"not-an-email","password":"secret"}'
+assert_status 400 "invalid email format is rejected"
+
+request POST /employees --auth "$employer_token" --data \
+  '{"firstName":"Test","lastName":"User","email":"x@example.com"}'
+assert_status 400 "missing password is rejected"
+
+section "POST /employees — duplicate email"
+
+request POST /employees --auth "$employer_token" --data \
+  "{\"firstName\":\"Dup\",\"lastName\":\"User\",\"email\":\"$EMPLOYER_EMAIL\",\"password\":\"secret\"}"
+assert_status 409 "duplicate email is rejected with 409"
+
+summary

--- a/backend/scripts/api/test-schedule.sh
+++ b/backend/scripts/api/test-schedule.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Integration tests for the /schedule endpoints.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=./_common.sh
+source ./_common.sh
+
+check_server
+
+# Monday/Thursday of the current week — matches the seed's weekDates.
+dow=$(date +%u)
+monday=$(date -v-$((dow - 1))d +%Y-%m-%d)
+thursday=$(date -v+$((4 - dow))d +%Y-%m-%d)
+
+employer_token=$(login "$EMPLOYER_EMAIL" "$PASSWORD")
+juan_token=$(login "juan.garcia@company.com" "$PASSWORD")
+
+if [ -z "$employer_token" ] || [ -z "$juan_token" ]; then
+  fail "could not obtain login tokens — is the DB seeded?"
+  summary
+fi
+
+# Pick Juan's and Maria's ids out of the employer's GET /employees list.
+request GET /employees --auth "$employer_token"
+juan_id=$(printf '%s' "$RESPONSE_BODY" | jq -r '.employees[] | select(.email=="juan.garcia@company.com") | .id')
+maria_id=$(printf '%s' "$RESPONSE_BODY" | jq -r '.employees[] | select(.email=="maria.fernandez@company.com") | .id')
+
+if [ -z "$juan_id" ] || [ -z "$maria_id" ]; then
+  fail "could not find seeded employee ids"
+  summary
+fi
+
+info "Monday=$monday  Thursday=$thursday  juan=$juan_id  maria=$maria_id"
+
+section "GET /schedule — happy path"
+
+request GET /schedule --auth "$employer_token"
+assert_status 200 "employer can list the full schedule"
+count=$(printf '%s' "$RESPONSE_BODY" | jq '.schedule | length')
+if [ "$count" -ge 7 ]; then
+  pass "response contains at least the 7 seeded entries (got $count)"
+else
+  fail "expected >= 7 schedule entries, got $count"
+fi
+assert_json_field '.schedule[0].employee.firstName' 'Pedro' "entries include nested employee object"
+
+request GET /schedule --auth "$juan_token"
+assert_status 200 "employee can list own schedule"
+only_juan=$(printf '%s' "$RESPONSE_BODY" | jq "[.schedule[] | select(.employee.id != \"$juan_id\")] | length")
+if [ "$only_juan" -eq 0 ]; then
+  pass "employee sees only own entries"
+else
+  fail "employee saw $only_juan entries belonging to others"
+fi
+
+section "GET /schedule — filters"
+
+request GET "/schedule?weekOf=$monday" --auth "$employer_token"
+assert_status 200 "weekOf filter returns 200"
+
+request GET "/schedule?employeeId=$juan_id" --auth "$employer_token"
+assert_status 200 "employer can filter by employeeId"
+non_juan=$(printf '%s' "$RESPONSE_BODY" | jq "[.schedule[] | select(.employee.id != \"$juan_id\")] | length")
+if [ "$non_juan" -eq 0 ]; then
+  pass "employeeId filter scopes result"
+else
+  fail "employeeId filter leaked $non_juan non-matching entries"
+fi
+
+section "GET /schedule — scoping overrides query"
+
+request GET "/schedule?employeeId=$maria_id" --auth "$juan_token"
+assert_status 200 "employee querying another's schedule still succeeds"
+leaked=$(printf '%s' "$RESPONSE_BODY" | jq "[.schedule[] | select(.employee.id != \"$juan_id\")] | length")
+if [ "$leaked" -eq 0 ]; then
+  pass "employee scoping overrides the employeeId query param"
+else
+  fail "employee saw $leaked of another employee's entries"
+fi
+
+section "GET /schedule — validation"
+
+request GET "/schedule?weekOf=$monday&startDate=$monday" --auth "$employer_token"
+assert_status 400 "weekOf + startDate together is rejected"
+
+request GET "/schedule?startDate=2026-01-10&endDate=2026-01-01" --auth "$employer_token"
+assert_status 400 "startDate after endDate is rejected"
+
+request GET "/schedule?employeeId=not-a-uuid" --auth "$employer_token"
+assert_status 400 "invalid employeeId format is rejected"
+
+section "GET /schedule — not found"
+
+request GET "/schedule?employeeId=00000000-0000-0000-0000-000000000000" --auth "$employer_token"
+assert_status 404 "unknown employeeId returns 404"
+
+section "PUT /schedule — happy path"
+
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"MORNING\",\"employeeId\":\"$juan_id\"}]}"
+assert_status 200 "employer can assign a new shift"
+assert_json_field '.schedule[0].employee.id' "$juan_id" "response carries the assigned employee"
+assert_json_field '.schedule[0].shiftType' 'MORNING' "response carries the shiftType"
+
+# Re-PUT the same tuple — should be a noop (upsert update: {}).
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"MORNING\",\"employeeId\":\"$juan_id\"}]}"
+assert_status 200 "re-put of the same tuple is idempotent"
+
+section "PUT /schedule — authorization"
+
+request PUT /schedule --auth "$juan_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"MORNING\",\"employeeId\":\"$juan_id\"}]}"
+assert_status 403 "employee cannot put the schedule"
+
+section "PUT /schedule — validation"
+
+request PUT /schedule --auth "$employer_token" --data '{}'
+assert_status 400 "missing entries is rejected"
+
+request PUT /schedule --auth "$employer_token" --data '{"entries":[]}'
+assert_status 400 "empty entries array is rejected"
+
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"LUNCH\",\"employeeId\":\"$juan_id\"}]}"
+assert_status 400 "invalid shiftType is rejected"
+
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"not-a-date\",\"shiftType\":\"MORNING\",\"employeeId\":\"$juan_id\"}]}"
+assert_status 400 "invalid date is rejected"
+
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"MORNING\",\"employeeId\":\"not-a-uuid\"}]}"
+assert_status 400 "invalid employeeId format is rejected"
+
+section "PUT /schedule — not found"
+
+request PUT /schedule --auth "$employer_token" --data \
+  "{\"entries\":[{\"date\":\"$thursday\",\"shiftType\":\"MORNING\",\"employeeId\":\"00000000-0000-0000-0000-000000000000\"}]}"
+assert_status 404 "unknown employeeId returns 404"
+
+summary

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -7,7 +7,7 @@ export const login: RequestHandler<
   Record<string, string>,
   unknown,
   LoginInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     const result = await loginService(req.body);
     res.status(200).json(result);
@@ -17,6 +17,6 @@ export const login: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };

--- a/backend/src/controllers/availability.ts
+++ b/backend/src/controllers/availability.ts
@@ -1,8 +1,8 @@
 import type { RequestHandler } from 'express';
 import prisma from '../lib/prisma.js';
-import {
-  availabilityQuerySchema,
-  type UpdateAvailabilityInput,
+import type {
+  AvailabilityQueryInput,
+  UpdateAvailabilityInput,
 } from '../schema.js';
 import * as availabilityService from '../services/availability.js';
 
@@ -18,7 +18,12 @@ async function employeeOwnsAvailability(
   return employee?.id === targetEmployeeId;
 }
 
-export const get: RequestHandler<{ employeeId: string }> = async (req, res) => {
+export const get: RequestHandler<
+  { employeeId: string },
+  unknown,
+  never,
+  AvailabilityQueryInput
+> = async (req, res) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -26,16 +31,7 @@ export const get: RequestHandler<{ employeeId: string }> = async (req, res) => {
     }
 
     const { employeeId } = req.params;
-    const parsedQuery = availabilityQuerySchema.safeParse(req.query);
-    if (!parsedQuery.success) {
-      res.status(400).json({
-        error: 'Validation error',
-        details: parsedQuery.error.flatten(),
-      });
-      return;
-    }
-
-    const { weekOf, startDate, endDate } = parsedQuery.data;
+    const { weekOf, startDate, endDate } = req.query;
 
     if (req.user.role === 'EMPLOYEE') {
       const canAccess = await employeeOwnsAvailability(

--- a/backend/src/controllers/availability.ts
+++ b/backend/src/controllers/availability.ts
@@ -23,7 +23,7 @@ export const get: RequestHandler<
   unknown,
   never,
   AvailabilityQueryInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -57,7 +57,7 @@ export const get: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };
 
@@ -65,7 +65,7 @@ export const update: RequestHandler<
   { employeeId: string },
   unknown,
   UpdateAvailabilityInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -93,6 +93,6 @@ export const update: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };

--- a/backend/src/controllers/employees.ts
+++ b/backend/src/controllers/employees.ts
@@ -6,12 +6,12 @@ import {
 } from '../services/employees.js';
 import type { CreateEmployeeInput } from '../schema.js';
 
-export const getAll: RequestHandler = async (_req, res) => {
+export const getAll: RequestHandler = async (_req, res, next) => {
   try {
     const employees = await getAllEmployees();
     res.status(200).json({ employees });
-  } catch {
-    res.status(500).json({ error: 'Internal server error' });
+  } catch (error) {
+    next(error);
   }
 };
 
@@ -19,7 +19,7 @@ export const create: RequestHandler<
   Record<string, never>,
   unknown,
   CreateEmployeeInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     const employee = await createEmployeeRecord(req.body);
     res.status(201).json({ employee });
@@ -29,11 +29,15 @@ export const create: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };
 
-export const getById: RequestHandler<{ id: string }> = async (req, res) => {
+export const getById: RequestHandler<{ id: string }> = async (
+  req,
+  res,
+  next,
+) => {
   try {
     const employee = await getEmployeeById(req.params.id);
     if (!employee) {
@@ -42,7 +46,7 @@ export const getById: RequestHandler<{ id: string }> = async (req, res) => {
     }
 
     res.status(200).json({ employee });
-  } catch {
-    res.status(500).json({ error: 'Internal server error' });
+  } catch (error) {
+    next(error);
   }
 };

--- a/backend/src/controllers/schedule.ts
+++ b/backend/src/controllers/schedule.ts
@@ -1,24 +1,20 @@
 import type { RequestHandler } from 'express';
-import { scheduleQuerySchema, type UpdateScheduleInput } from '../schema.js';
+import type { ScheduleQueryInput, UpdateScheduleInput } from '../schema.js';
 import { getSchedule, updateSchedule } from '../services/schedule.js';
 
-export const get: RequestHandler = async (req, res) => {
+export const get: RequestHandler<
+  Record<string, never>,
+  unknown,
+  never,
+  ScheduleQueryInput
+> = async (req, res) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
       return;
     }
 
-    const parsedQuery = scheduleQuerySchema.safeParse(req.query);
-    if (!parsedQuery.success) {
-      res.status(400).json({
-        error: 'Validation error',
-        details: parsedQuery.error.flatten(),
-      });
-      return;
-    }
-
-    const { weekOf, startDate, endDate, employeeId } = parsedQuery.data;
+    const { weekOf, startDate, endDate, employeeId } = req.query;
 
     const result = await getSchedule({
       userId: req.user.userId,

--- a/backend/src/controllers/schedule.ts
+++ b/backend/src/controllers/schedule.ts
@@ -7,7 +7,7 @@ export const get: RequestHandler<
   unknown,
   never,
   ScheduleQueryInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -32,7 +32,7 @@ export const get: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };
 
@@ -40,7 +40,7 @@ export const update: RequestHandler<
   Record<string, never>,
   unknown,
   UpdateScheduleInput
-> = async (req, res) => {
+> = async (req, res, next) => {
   try {
     if (!req.user) {
       res.status(401).json({ error: 'Not authenticated' });
@@ -55,6 +55,6 @@ export const update: RequestHandler<
       return;
     }
 
-    res.status(500).json({ error: 'Internal server error' });
+    next(error);
   }
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,16 @@ import logger from './lib/logger.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { requestLogger } from './middleware/requestLogger.js';
 
+// Fail-fast config check. Any required env var missing here should crash
+// the process at startup rather than silently returning 500s per request.
+const REQUIRED_ENV = ['DATABASE_URL', 'JWT_SECRET'] as const;
+for (const key of REQUIRED_ENV) {
+  if (!process.env[key]) {
+    logger.error(`${key} is required but not set. Refusing to start.`);
+    process.exit(1);
+  }
+}
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -2,14 +2,58 @@ import { createLogger, format, transports } from 'winston';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+const prodFormat = format.combine(
+  format.timestamp(),
+  format.errors({ stack: true }),
+  format.splat(),
+  format.json(),
+);
+
+function str(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+const devFormat = format.combine(
+  format.timestamp({ format: 'HH:mm:ss' }),
+  format.errors({ stack: true }),
+  format.splat(),
+  format.colorize({ level: true }),
+  format.printf((info) => {
+    const meta = { ...info } as Record<string, unknown>;
+    const timestamp = str(meta.timestamp);
+    const level = str(meta.level);
+    const message = str(meta.message);
+    delete meta.timestamp;
+    delete meta.level;
+    delete meta.message;
+
+    // HTTP request lines — inline the well-known fields in fixed columns.
+    if (message === 'HTTP request') {
+      const method = str(meta.method).padEnd(6);
+      const path = str(meta.path).padEnd(50);
+      const status = str(meta.statusCode);
+      const duration = `${str(meta.durationMs).padStart(4)}ms`;
+      return `${timestamp} ${level} HTTP ${method}${path} ${status}  ${duration}`;
+    }
+
+    // Everything else: message + compact JSON meta; stack (if present) on a new line.
+    const stack = meta.stack;
+    delete meta.stack;
+    const metaStr =
+      Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
+    const stackStr = stack ? `\n${str(stack)}` : '';
+    return `${timestamp} ${level} ${message}${metaStr}${stackStr}`;
+  }),
+);
+
 const logger = createLogger({
   level: process.env.LOG_LEVEL ?? (isProduction ? 'info' : 'debug'),
-  format: format.combine(
-    format.timestamp(),
-    format.errors({ stack: true }),
-    format.splat(),
-    format.json(),
-  ),
+  format: isProduction ? prodFormat : devFormat,
   transports: [new transports.Console()],
 });
 

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -4,13 +4,8 @@ import type { PrismaClient as PrismaClientType } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 
-const connectionString = process.env.DATABASE_URL;
-
-if (!connectionString) {
-  throw new Error('DATABASE_URL is required');
-}
-
-const pool = new Pool({ connectionString });
+// DATABASE_URL presence is guaranteed by the startup check in index.ts.
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const adapter = new PrismaPg(pool);
 
 const prisma = new PrismaClient({ adapter }) as PrismaClientType;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -38,14 +38,12 @@ export function authenticate(
     return;
   }
 
-  const secret = process.env.JWT_SECRET;
-  if (!secret) {
-    res.status(500).json({ error: 'JWT_SECRET is not configured' });
-    return;
-  }
-
+  // JWT_SECRET presence is guaranteed by the startup check in index.ts.
   try {
-    const decoded = jwt.verify(token, secret) as JwtPayload;
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET as string,
+    ) as JwtPayload;
     req.user = {
       userId: decoded.userId,
       role: decoded.role,

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,16 +1,24 @@
-// validate(schema) — generic factory, returns middleware that:
-//   - Parses req.body against the given Zod schema
-//   - On success: replaces req.body with parsed data (strips unknown fields), calls next()
+// validate(schema, source?) — generic factory, returns middleware that:
+//   - Parses the given request source (body by default, or query) with the schema
+//   - On success: replaces the source with parsed data (strips unknown fields), calls next()
 //   - On failure: returns 400 with Zod error details
 //
-// Usage in routes: router.post('/', validate(createEmployeeSchema), controller.create)
+// Usage:
+//   router.post('/', validate(createEmployeeSchema), controller.create)
+//   router.get('/', validate(scheduleQuerySchema, 'query'), controller.get)
 
 import type { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 
-export function validate(schema: z.ZodTypeAny) {
+type ValidateSource = 'body' | 'query';
+
+export function validate(
+  schema: z.ZodTypeAny,
+  source: ValidateSource = 'body',
+) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const result = schema.safeParse(req.body);
+    const input = source === 'body' ? req.body : req.query;
+    const result = schema.safeParse(input);
 
     if (!result.success) {
       res.status(400).json({
@@ -20,7 +28,9 @@ export function validate(schema: z.ZodTypeAny) {
       return;
     }
 
-    req.body = result.data;
+    if (source === 'body') {
+      req.body = result.data;
+    }
     next();
   };
 }

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -15,7 +15,7 @@ export function validate(schema: z.ZodTypeAny) {
     if (!result.success) {
       res.status(400).json({
         error: 'Validation error',
-        details: result.error.flatten(),
+        details: z.flattenError(result.error),
       });
       return;
     }

--- a/backend/src/routes/availability.ts
+++ b/backend/src/routes/availability.ts
@@ -5,12 +5,20 @@ import {
 } from '../controllers/availability.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
-import { updateAvailabilitySchema } from '../schema.js';
+import {
+  availabilityQuerySchema,
+  updateAvailabilitySchema,
+} from '../schema.js';
 
 const router = Router();
 
 // GET /:employeeId    — both roles (employee can only view own) → availabilityController.get
-router.get('/:employeeId', authenticate, getAvailability);
+router.get(
+  '/:employeeId',
+  authenticate,
+  validate(availabilityQuerySchema, 'query'),
+  getAvailability,
+);
 
 // PUT /:employeeId    — employee only (own data), validate body → availabilityController.update
 router.put(

--- a/backend/src/routes/schedule.ts
+++ b/backend/src/routes/schedule.ts
@@ -2,12 +2,17 @@ import { Router } from 'express';
 import * as scheduleController from '../controllers/schedule.js';
 import { authenticate, requireRole } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
-import { updateScheduleSchema } from '../schema.js';
+import { scheduleQuerySchema, updateScheduleSchema } from '../schema.js';
 
 const router = Router();
 
 // GET /     — both roles (employee sees own shifts only), supports ?weekOf query → scheduleController.get
-router.get('/', authenticate, scheduleController.get);
+router.get(
+  '/',
+  authenticate,
+  validate(scheduleQuerySchema, 'query'),
+  scheduleController.get,
+);
 
 // PUT /     — employer only, validate body → scheduleController.update
 router.put(

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -12,7 +12,7 @@
 import { z } from 'zod';
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(1),
 });
 
@@ -23,11 +23,11 @@ const shiftTypeSchema = z.enum(['MORNING', 'AFTERNOON', 'NIGHT']);
 export const createEmployeeSchema = z.object({
   firstName: z.string().min(1),
   lastName: z.string().min(1),
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(1),
   phone: z.string().min(1).optional(),
   position: z.string().min(1).optional(),
-  avatar: z.string().url().optional(),
+  avatar: z.url().optional(),
 });
 
 export type CreateEmployeeInput = z.infer<typeof createEmployeeSchema>;
@@ -36,7 +36,7 @@ export const updateAvailabilitySchema = z.object({
   entries: z
     .array(
       z.object({
-        date: z.string().date(),
+        date: z.iso.date(),
         shiftType: shiftTypeSchema,
         isAvailable: z.boolean(),
       }),
@@ -48,14 +48,14 @@ export type UpdateAvailabilityInput = z.infer<typeof updateAvailabilitySchema>;
 
 export const availabilityQuerySchema = z
   .object({
-    weekOf: z.string().date().optional(),
-    startDate: z.string().date().optional(),
-    endDate: z.string().date().optional(),
+    weekOf: z.iso.date().optional(),
+    startDate: z.iso.date().optional(),
+    endDate: z.iso.date().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.weekOf && (value.startDate || value.endDate)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         message: 'Use either weekOf or startDate/endDate, not both',
       });
     }
@@ -65,7 +65,7 @@ export const availabilityQuerySchema = z
       const end = new Date(value.endDate);
       if (start > end) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'startDate must be before or equal to endDate',
         });
       }
@@ -78,9 +78,9 @@ export const updateScheduleSchema = z.object({
   entries: z
     .array(
       z.object({
-        date: z.string().date(),
+        date: z.iso.date(),
         shiftType: shiftTypeSchema,
-        employeeId: z.string().uuid(),
+        employeeId: z.uuid(),
       }),
     )
     .min(1),
@@ -90,15 +90,15 @@ export type UpdateScheduleInput = z.infer<typeof updateScheduleSchema>;
 
 export const scheduleQuerySchema = z
   .object({
-    weekOf: z.string().date().optional(),
-    startDate: z.string().date().optional(),
-    endDate: z.string().date().optional(),
-    employeeId: z.string().uuid().optional(),
+    weekOf: z.iso.date().optional(),
+    startDate: z.iso.date().optional(),
+    endDate: z.iso.date().optional(),
+    employeeId: z.uuid().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.weekOf && (value.startDate || value.endDate)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         message: 'Use either weekOf or startDate/endDate, not both',
       });
     }
@@ -108,7 +108,7 @@ export const scheduleQuerySchema = z
       const end = new Date(value.endDate);
       if (start > end) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'startDate must be before or equal to endDate',
         });
       }

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -30,14 +30,12 @@ export async function login(input: LoginInput): Promise<LoginResult> {
     throw new Error('Invalid credentials');
   }
 
-  const secret = process.env.JWT_SECRET;
-  if (!secret) {
-    throw new Error('JWT_SECRET is not configured');
-  }
-
-  const token = jwt.sign({ userId: user.id, role: user.role }, secret, {
-    expiresIn: '7d',
-  });
+  // JWT_SECRET presence is guaranteed by the startup check in index.ts.
+  const token = jwt.sign(
+    { userId: user.id, role: user.role },
+    process.env.JWT_SECRET as string,
+    { expiresIn: '7d' },
+  );
 
   return {
     token,

--- a/backend/src/services/employees.ts
+++ b/backend/src/services/employees.ts
@@ -48,7 +48,6 @@ export const createEmployeeRecord = async (
     const created = await prisma.$transaction(async (tx) => {
       const user = await tx.user.create({
         data: {
-          name: `${firstName} ${lastName}`,
           email,
           passwordHash,
           role: 'EMPLOYEE',

--- a/backend/src/services/employees.ts
+++ b/backend/src/services/employees.ts
@@ -10,7 +10,7 @@ type EmployeeView = {
   email: string;
   phone: string | null;
   position: string | null;
-  avatar: string;
+  avatar: string | null;
 };
 
 export const getAllEmployees = async (): Promise<EmployeeView[]> => {
@@ -61,7 +61,7 @@ export const createEmployeeRecord = async (
           lastName,
           phone,
           position,
-          avatar: avatar ?? '',
+          avatar: avatar ?? null,
         },
       });
     });

--- a/backend/src/services/employees.ts
+++ b/backend/src/services/employees.ts
@@ -16,20 +16,14 @@ type EmployeeView = {
 export const getAllEmployees = async (): Promise<EmployeeView[]> => {
   const rows = await prisma.employee.findMany({
     orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+    include: { user: { select: { email: true } } },
   });
-
-  const userIds = rows.map((row) => row.userId);
-  const users = await prisma.user.findMany({
-    where: { id: { in: userIds } },
-    select: { id: true, email: true },
-  });
-  const userEmailById = new Map(users.map((user) => [user.id, user.email]));
 
   return rows.map((row) => ({
     id: row.id,
     firstName: row.firstName,
     lastName: row.lastName,
-    email: userEmailById.get(row.userId) ?? '',
+    email: row.user.email,
     phone: row.phone,
     position: row.position,
     avatar: row.avatar,
@@ -92,20 +86,16 @@ export const getEmployeeById = async (
 ): Promise<EmployeeView | null> => {
   const employee = await prisma.employee.findUnique({
     where: { id },
+    include: { user: { select: { email: true } } },
   });
 
   if (!employee) return null;
-
-  const user = await prisma.user.findUnique({
-    where: { id: employee.userId },
-    select: { email: true },
-  });
 
   return {
     id: employee.id,
     firstName: employee.firstName,
     lastName: employee.lastName,
-    email: user?.email ?? '',
+    email: employee.user.email,
     phone: employee.phone,
     position: employee.position,
     avatar: employee.avatar,


### PR DESCRIPTION
Review of the backend that landed via PR #22. Worked through issues #4-#11 in order, building an integration test suite along the way (#12).

**Per-issue summary**

- **#4 Prisma** - init migration was out of sync with the schema (avatar NOT NULL, missing `Employee.userId` FK); added a fix migration. Dropped unused `User.name`. Fixed `EmployeeView.avatar` nullability. Extended seed with a week of availability + partial schedule. Added `db:*` npm scripts. Fixed a timezone bug in the seed (surfaced by #7's tests). `db:reset` now chains seed since Prisma 7 doesn't auto-run it.
- **#5 Auth** - fail-fast startup check for `JWT_SECRET` + `DATABASE_URL` (was being checked per-request, would 500 on every call if missing). Added `test:auth` with 15 assertions. Fixed `lint` script that silently mutated files.
- **#6 Employees** - added `test:employees` (19 assertions). Refactored the employee join services to use Prisma's `include` instead of two queries + manual Map.
- **#7 Availability** - added `test:availability` (22 assertions).
- **#8 Schedule** - added `test:schedule` (25 assertions). Endpoint code needed no functional fixes.
- **#9 Zod** - Zod 4 deprecation sweep (`z.string().email()` → `z.email()` etc., `error.flatten()` → `z.flattenError()`). Extended `validate` middleware to handle `req.query`, removed inline `safeParse` blocks from availability and schedule controllers.
- **#10 Error handling** - Controllers were short-circuiting 500s in their catch blocks, so the global `errorHandler` never saw unknown errors. Swapped `res.status(500)` for `next(error)` so the handler now gets the full picture with stack traces. Minimal change; kept the existing string-match dispatch for known 4xx errors.
- **#11 Logging** - Dev logs were JSON-per-line and hard to scan. Added a pretty format for dev (single-line HTTP rows with fixed columns); JSON preserved in production. Documented `NODE_ENV` and `LOG_LEVEL` in `.env-example` and the README.
- **#12 Manual testing + cleanup** - Built out the `scripts/api/` test harness along the way; wired `npm test` as the aggregator. 81 assertions across 4 suites, all passing.

**How to review**
- 24 commits, each tagged with the issue it addresses.
- Commits are scoped and readable top-to-bottom as a review story (scripts → fixes → refactors → docs).
- To verify locally: `npm run db:reset && npm run dev` (terminal 1) + `npm test` (terminal 2). Also `npm run check` for typecheck + lint + format.

Closes #4, #5, #6, #7, #8, #9, #10, #11, #12.